### PR TITLE
エアコン制御の判断関数を追加

### DIFF
--- a/temp_controller/temp_controller.go
+++ b/temp_controller/temp_controller.go
@@ -66,33 +66,34 @@ func Get_current_temperature(device device.Device) CurrentTempreture {
 	return current_tempreture
 }
 
-// 新settingを作る
-func buildNewAirconSettings(current_aircon_setting CurrentAirConSettings, current_tempreture CurrentTempreture, temptureMaxMinSettings TempretureMaxMinSettings) (NewAirConSettings, error) {
-	var no_error error = nil
-	currentTimeJST := ConvertUTCToJST(time.Now())
+func DecideAirconControl(current_aircon_setting CurrentAirConSettings, current_tempreture CurrentTempreture, temptureMaxMinSettings TempretureMaxMinSettings, now time.Time) AirconDecision {
+	currentTimeJST := ConvertUTCToJST(now)
 
 	// 電源がオフなら No Change
 	if !current_aircon_setting.PowerOn {
-		return NewAirConSettings{
-			AirconSettings: current_aircon_setting.AirconSettings,
-			PowerOn:        false,
-		}, errors.New("No Change")
+		return AirconDecision{
+			Action:   AirconActionNoChange,
+			Settings: current_aircon_setting.AirconSettings,
+			Reason:   "power is off",
+		}
 	}
 
 	// 気温を測定した時刻が前回の変更から10分以内なら No Change
 	if current_tempreture.UpdatedAt.Sub(current_aircon_setting.UpdatedAt).Minutes() < 10.0 {
-		return NewAirConSettings{
-			AirconSettings: current_aircon_setting.AirconSettings,
-			PowerOn:        true,
-		}, errors.New("No Change")
+		return AirconDecision{
+			Action:   AirconActionNoChange,
+			Settings: current_aircon_setting.AirconSettings,
+			Reason:   "temperature measurement is too close to the last aircon update",
+		}
 	}
 
 	// 前回変更から15分以内なら No Change
 	if currentTimeJST.Sub(current_aircon_setting.UpdatedAt).Minutes() < 14.0 {
-		return NewAirConSettings{
-			AirconSettings: current_aircon_setting.AirconSettings,
-			PowerOn:        true,
-		}, errors.New("No Change")
+		return AirconDecision{
+			Action:   AirconActionNoChange,
+			Settings: current_aircon_setting.AirconSettings,
+			Reason:   "last aircon update is too recent",
+		}
 	}
 
 	// too hot なら温度下げる
@@ -100,16 +101,16 @@ func buildNewAirconSettings(current_aircon_setting CurrentAirConSettings, curren
 
 		new_temperature := max(current_aircon_setting.AirconSettings.Temperature-0.5, temptureMaxMinSettings.MinimumTemperatureSetting)
 
-		new_aircon_setting := NewAirConSettings{
-			AirconSettings: signal.AirconSettings{
+		return AirconDecision{
+			Action: AirconActionChangeSetting,
+			Settings: signal.AirconSettings{
 				OperationMode: current_aircon_setting.AirconSettings.OperationMode,
 				Temperature:   new_temperature,
 				AirVolume:     current_aircon_setting.AirconSettings.AirVolume,
 				AirDirection:  current_aircon_setting.AirconSettings.AirDirection,
 			},
-			PowerOn: true,
+			Reason: "temperature is too hot",
 		}
-		return new_aircon_setting, no_error
 	}
 
 	// too cold なら温度上げる
@@ -117,16 +118,16 @@ func buildNewAirconSettings(current_aircon_setting CurrentAirConSettings, curren
 
 		new_temperature := min(current_aircon_setting.AirconSettings.Temperature+0.5, temptureMaxMinSettings.MaximumTemperatureSetting)
 
-		new_aircon_setting := NewAirConSettings{
-			AirconSettings: signal.AirconSettings{
+		return AirconDecision{
+			Action: AirconActionChangeSetting,
+			Settings: signal.AirconSettings{
 				OperationMode: current_aircon_setting.AirconSettings.OperationMode,
 				Temperature:   new_temperature,
 				AirVolume:     current_aircon_setting.AirconSettings.AirVolume,
 				AirDirection:  current_aircon_setting.AirconSettings.AirDirection,
 			},
-			PowerOn: true,
+			Reason: "temperature is too cold",
 		}
-		return new_aircon_setting, no_error
 	}
 	// 1時間以上設定変更されていなければ一度今の温度を再送信（エアコンの設定が自動で変わる問題が確認されているため）
 	time_diff := currentTimeJST.Sub(current_aircon_setting.UpdatedAt)
@@ -134,23 +135,40 @@ func buildNewAirconSettings(current_aircon_setting CurrentAirConSettings, curren
 
 		new_temperature := max(current_aircon_setting.AirconSettings.Temperature, temptureMaxMinSettings.MinimumTemperatureSetting)
 
-		new_aircon_setting := NewAirConSettings{
-			AirconSettings: signal.AirconSettings{
+		return AirconDecision{
+			Action: AirconActionResendSetting,
+			Settings: signal.AirconSettings{
 				OperationMode: current_aircon_setting.AirconSettings.OperationMode,
 				Temperature:   new_temperature,
 				AirVolume:     current_aircon_setting.AirconSettings.AirVolume,
 				AirDirection:  current_aircon_setting.AirconSettings.AirDirection,
 			},
-			PowerOn: true,
+			Reason: "last aircon update is older than resend interval",
 		}
-		return new_aircon_setting, no_error
 	}
 
 	// 特に問題なしなら 現状のまま を返す
+	return AirconDecision{
+		Action:   AirconActionNoChange,
+		Settings: current_aircon_setting.AirconSettings,
+		Reason:   "temperature is within thresholds",
+	}
+}
+
+// 新settingを作る
+func buildNewAirconSettings(current_aircon_setting CurrentAirConSettings, current_tempreture CurrentTempreture, temptureMaxMinSettings TempretureMaxMinSettings) (NewAirConSettings, error) {
+	decision := DecideAirconControl(current_aircon_setting, current_tempreture, temptureMaxMinSettings, time.Now())
+	new_aircon_settings := NewAirConSettings{
+		AirconSettings: decision.Settings,
+		PowerOn:        current_aircon_setting.PowerOn,
+	}
+	if decision.Action == AirconActionNoChange {
+		return new_aircon_settings, errors.New("No Change")
+	}
 	return NewAirConSettings{
-		AirconSettings: current_aircon_setting.AirconSettings,
+		AirconSettings: decision.Settings,
 		PowerOn:        true,
-	}, errors.New("No Change")
+	}, nil
 }
 
 func Find_aircon_appliance(appliances []appliance.Appliance) (appliance.Appliance, error) {

--- a/temp_controller/temp_controller_test.go
+++ b/temp_controller/temp_controller_test.go
@@ -312,6 +312,89 @@ func TestBuildNewAirconSettings(t *testing.T) {
 	}
 }
 
+func TestDecideAirconControl(t *testing.T) {
+	tokyoTZ, _ := time.LoadLocation("Asia/Tokyo")
+	settings := TempretureMaxMinSettings{
+		TooHotThreshold:           27.5,
+		TooColdThreshold:          24.0,
+		PreparationThreshold:      0.5,
+		MinimumTemperatureSetting: 23.0,
+		MaximumTemperatureSetting: 30.0,
+	}
+	currentAircon := CurrentAirConSettings{
+		AirconSettings: signal.AirconSettings{
+			OperationMode: "cool",
+			Temperature:   27.0,
+			AirVolume:     "auto",
+			AirDirection:  "auto",
+		},
+		UpdatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, tokyoTZ),
+		PowerOn:   true,
+	}
+
+	tests := []struct {
+		name               string
+		currentAircon      CurrentAirConSettings
+		currentTempreture  CurrentTempreture
+		now                time.Time
+		wantAction         AirconAction
+		wantTemperature    float64
+		wantReasonNotEmpty bool
+	}{
+		{
+			name:          "tooHot",
+			currentAircon: currentAircon,
+			currentTempreture: CurrentTempreture{
+				Tempreture: 30.0,
+				UpdatedAt:  time.Date(2020, 1, 1, 5, 0, 0, 0, tokyoTZ),
+			},
+			now:                time.Date(2020, 1, 1, 6, 0, 0, 0, tokyoTZ),
+			wantAction:         AirconActionChangeSetting,
+			wantTemperature:    26.5,
+			wantReasonNotEmpty: true,
+		},
+		{
+			name:          "resend",
+			currentAircon: currentAircon,
+			currentTempreture: CurrentTempreture{
+				Tempreture: 25.0,
+				UpdatedAt:  time.Date(2020, 1, 1, 5, 0, 0, 0, tokyoTZ),
+			},
+			now:                time.Date(2020, 1, 1, 1, 0, 0, 0, tokyoTZ),
+			wantAction:         AirconActionResendSetting,
+			wantTemperature:    27.0,
+			wantReasonNotEmpty: true,
+		},
+		{
+			name:          "noChange",
+			currentAircon: currentAircon,
+			currentTempreture: CurrentTempreture{
+				Tempreture: 25.0,
+				UpdatedAt:  time.Date(2020, 1, 1, 0, 5, 0, 0, tokyoTZ),
+			},
+			now:                time.Date(2020, 1, 1, 1, 0, 0, 0, tokyoTZ),
+			wantAction:         AirconActionNoChange,
+			wantTemperature:    27.0,
+			wantReasonNotEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecideAirconControl(tt.currentAircon, tt.currentTempreture, settings, tt.now)
+			if got.Action != tt.wantAction {
+				t.Errorf("DecideAirconControl action mismatch. Must be %v, got %v\n", tt.wantAction, got.Action)
+			}
+			if got.Settings.Temperature != tt.wantTemperature {
+				t.Errorf("DecideAirconControl temperature mismatch. Must be %v, got %v\n", tt.wantTemperature, got.Settings.Temperature)
+			}
+			if tt.wantReasonNotEmpty && got.Reason == "" {
+				t.Errorf("DecideAirconControl reason must not be empty")
+			}
+		})
+	}
+}
+
 func TestBuildNewAirconOrderParameters(t *testing.T) {
 	type Args struct {
 		appliances             []appliance.Appliance


### PR DESCRIPTION
## 概要
- エアコン制御の判断を AirconDecision として返す DecideAirconControl を追加しました
- 既存の buildNewAirconSettings は互換ラッパーとして残し、呼び出し側の挙動を維持しました
- 判断結果の Action と Reason をテストできるようにしました

## テスト
- go test ./...