### PR TITLE
温度アラートの判断を分離

### DIFF
--- a/temp_controller/temp_monitor.go
+++ b/temp_controller/temp_monitor.go
@@ -8,23 +8,52 @@ import (
 	"github.com/mski-iksm/home_controller/device"
 )
 
+func DecideTemperatureAlert(current_tempreture CurrentTempreture, temptureMaxMinSettings TempretureMaxMinSettings) TemperatureAlert {
+	if current_tempreture.Tempreture >= temptureMaxMinSettings.TooHotThreshold+0.5 {
+		return TemperatureAlert{
+			ShouldNotify: true,
+			Message:      "緊急アラート: 現在の温度が設定値を超えています。\n現在温度: " + fmt.Sprintf("%.1f", current_tempreture.Tempreture) + "\n設定温度: " + fmt.Sprintf("%.1f", temptureMaxMinSettings.TooHotThreshold),
+			Priority:     "5",
+			Reason:       "temperature is too hot",
+		}
+	}
+
+	if current_tempreture.Tempreture <= temptureMaxMinSettings.TooColdThreshold-0.5 {
+		return TemperatureAlert{
+			ShouldNotify: true,
+			Message:      "緊急アラート: 現在の温度が設定値を下回っています。\n現在温度: " + fmt.Sprintf("%.1f", current_tempreture.Tempreture) + "\n設定温度: " + fmt.Sprintf("%.1f", temptureMaxMinSettings.TooColdThreshold),
+			Priority:     "5",
+			Reason:       "temperature is too cold",
+		}
+	}
+
+	return TemperatureAlert{
+		ShouldNotify: false,
+		Reason:       "temperature is within alert thresholds",
+	}
+}
+
+func SendTemperatureAlert(ntfyUrl string, alert TemperatureAlert) {
+	if !alert.ShouldNotify {
+		return
+	}
+
+	req, _ := http.NewRequest("POST", ntfyUrl, strings.NewReader(alert.Message))
+	req.Header.Set("Priority", alert.Priority)
+	http.DefaultClient.Do(req)
+}
+
 func MonitorTempreture(device device.Device, temptureMaxMinSettings TempretureMaxMinSettings, ntfyUrl string) {
 	// deviceから今の気温を取得
 	current_tempreture := Get_current_temperature(device)
 
-	// 現在気温が既定値を0.5度以上超えている場合は、緊急アラート
-	if current_tempreture.Tempreture >= temptureMaxMinSettings.TooHotThreshold+0.5 {
-		req, _ := http.NewRequest("POST", ntfyUrl, strings.NewReader("緊急アラート: 現在の温度が設定値を超えています。\n現在温度: "+fmt.Sprintf("%.1f", current_tempreture.Tempreture)+"\n設定温度: "+fmt.Sprintf("%.1f", temptureMaxMinSettings.TooHotThreshold)))
-		req.Header.Set("Priority", "5")
+	alert := DecideTemperatureAlert(current_tempreture, temptureMaxMinSettings)
+	if alert.Reason == "temperature is too hot" {
 		println("Sending hot alert to ntfy")
-		http.DefaultClient.Do(req)
 	}
-
-	if current_tempreture.Tempreture <= temptureMaxMinSettings.TooColdThreshold-0.5 {
-		req, _ := http.NewRequest("POST", ntfyUrl, strings.NewReader("緊急アラート: 現在の温度が設定値を下回っています。\n現在温度: "+fmt.Sprintf("%.1f", current_tempreture.Tempreture)+"\n設定温度: "+fmt.Sprintf("%.1f", temptureMaxMinSettings.TooColdThreshold)))
-		req.Header.Set("Priority", "5")
+	if alert.Reason == "temperature is too cold" {
 		println("Sending cold alert to ntfy")
 		println(ntfyUrl)
-		http.DefaultClient.Do(req)
 	}
+	SendTemperatureAlert(ntfyUrl, alert)
 }

--- a/temp_controller/temp_monitor.go
+++ b/temp_controller/temp_monitor.go
@@ -53,7 +53,6 @@ func MonitorTempreture(device device.Device, temptureMaxMinSettings TempretureMa
 	}
 	if alert.Reason == "temperature is too cold" {
 		println("Sending cold alert to ntfy")
-		println(ntfyUrl)
 	}
 	SendTemperatureAlert(ntfyUrl, alert)
 }

--- a/temp_controller/temp_monitor_test.go
+++ b/temp_controller/temp_monitor_test.go
@@ -1,0 +1,62 @@
+package temp_controller
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDecideTemperatureAlert(t *testing.T) {
+	settings := TempretureMaxMinSettings{
+		TooHotThreshold:  27.5,
+		TooColdThreshold: 24.0,
+	}
+
+	tests := []struct {
+		name        string
+		tempreture  float64
+		wantNotify  bool
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:        "tooHot",
+			tempreture:  28.0,
+			wantNotify:  true,
+			wantReason:  "temperature is too hot",
+			wantMessage: "設定値を超えています",
+		},
+		{
+			name:        "tooCold",
+			tempreture:  23.5,
+			wantNotify:  true,
+			wantReason:  "temperature is too cold",
+			wantMessage: "設定値を下回っています",
+		},
+		{
+			name:       "withinThresholds",
+			tempreture: 25.0,
+			wantNotify: false,
+			wantReason: "temperature is within alert thresholds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecideTemperatureAlert(CurrentTempreture{
+				Tempreture: tt.tempreture,
+				UpdatedAt:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			}, settings)
+
+			if got.ShouldNotify != tt.wantNotify {
+				t.Errorf("ShouldNotify mismatch. Must be %v, got %v\n", tt.wantNotify, got.ShouldNotify)
+			}
+			if got.Reason != tt.wantReason {
+				t.Errorf("Reason mismatch. Must be %v, got %v\n", tt.wantReason, got.Reason)
+			}
+			if tt.wantMessage != "" && !strings.Contains(got.Message, tt.wantMessage) {
+				t.Errorf("Message must contain %v, got %v\n", tt.wantMessage, got.Message)
+			}
+		})
+	}
+}

--- a/temp_controller/types.go
+++ b/temp_controller/types.go
@@ -33,6 +33,13 @@ type AirconDecision struct {
 	Reason   string
 }
 
+type TemperatureAlert struct {
+	ShouldNotify bool
+	Message      string
+	Priority     string
+	Reason       string
+}
+
 type CurrentTempreture struct {
 	Tempreture float64
 	UpdatedAt  time.Time


### PR DESCRIPTION
## 概要
- 温度アラートの判断を DecideTemperatureAlert に分離しました
- ntfy 送信処理を SendTemperatureAlert に切り出しました
- 既存の MonitorTempreture は互換入口として残しました
- アラート判断のテストを追加しました

## テスト
- go test ./...