### PR TITLE
温度制御サービスを interface 注入型に変更

### DIFF
--- a/service/temp_control_service.go
+++ b/service/temp_control_service.go
@@ -11,11 +11,8 @@ import (
 )
 
 type TempControlRequest struct {
-	NatureAPISecret string
-	DeviceName      string
-	Settings        temp_controller.TempretureMaxMinSettings
-	SlackObject     slack.SlackObject
-	NtfyURL         string
+	DeviceName string
+	Settings   temp_controller.TempretureMaxMinSettings
 }
 
 type TempControlResult struct {
@@ -25,17 +22,65 @@ type TempControlResult struct {
 	TemperatureAlert   temp_controller.TemperatureAlert
 }
 
-type TempControlService struct{}
+type NatureClient interface {
+	GetDevices() []device.Device
+	GetAppliances() []appliance.Appliance
+	PostAirconSignal(applianceID string, settings signal.AirconSettings) int
+}
 
-func NewTempControlService() TempControlService {
-	return TempControlService{}
+type SlackNotifier interface {
+	SendSlack(message string)
+}
+
+type TemperatureAlertNotifier interface {
+	SendTemperatureAlert(alert temp_controller.TemperatureAlert)
+}
+
+type NatureRemoClient struct {
+	APISecret string
+}
+
+func (c NatureRemoClient) GetDevices() []device.Device {
+	return device.Get_devices(c.APISecret)
+}
+
+func (c NatureRemoClient) GetAppliances() []appliance.Appliance {
+	return appliance.Build_appliances(c.APISecret)
+}
+
+func (c NatureRemoClient) PostAirconSignal(applianceID string, settings signal.AirconSettings) int {
+	return signal.PostAirconSignal(c.APISecret, applianceID, settings)
+}
+
+type NtfyNotifier struct {
+	URL string
+}
+
+func (n NtfyNotifier) SendTemperatureAlert(alert temp_controller.TemperatureAlert) {
+	temp_controller.SendTemperatureAlert(n.URL, alert)
+}
+
+type TempControlService struct {
+	NatureClient             NatureClient
+	SlackNotifier            SlackNotifier
+	TemperatureAlertNotifier TemperatureAlertNotifier
+}
+
+func NewTempControlService(natureAPISecret string, slackObject slack.SlackObject, ntfyURL string) TempControlService {
+	return TempControlService{
+		NatureClient: NatureRemoClient{
+			APISecret: natureAPISecret,
+		},
+		SlackNotifier:            &slackObject,
+		TemperatureAlertNotifier: NtfyNotifier{URL: ntfyURL},
+	}
 }
 
 func (s TempControlService) Run(request TempControlRequest) (TempControlResult, error) {
 	var result TempControlResult
 
-	devices := device.Get_devices(request.NatureAPISecret)
-	appliances := appliance.Build_appliances(request.NatureAPISecret)
+	devices := s.NatureClient.GetDevices()
+	appliances := s.NatureClient.GetAppliances()
 
 	selectedDevice, err := device.SelectDevice(devices, request.DeviceName)
 	if err != nil {
@@ -49,14 +94,14 @@ func (s TempControlService) Run(request TempControlRequest) (TempControlResult, 
 
 	temperatureAlert := temp_controller.DecideTemperatureAlert(currentTemperature, request.Settings)
 	result.TemperatureAlert = temperatureAlert
-	temp_controller.SendTemperatureAlert(request.NtfyURL, temperatureAlert)
+	s.TemperatureAlertNotifier.SendTemperatureAlert(temperatureAlert)
 
 	newAirconOrderParameters, err := temp_controller.BuildNewAirconOrderParameters(filteredAppliances, selectedDevice, request.Settings)
 	if err != nil {
 		return result, err
 	}
 
-	signal.PostAirconSignal(request.NatureAPISecret, newAirconOrderParameters.ApplianceId, newAirconOrderParameters.AirconSettings)
+	s.NatureClient.PostAirconSignal(newAirconOrderParameters.ApplianceId, newAirconOrderParameters.AirconSettings)
 
 	result.AirconSettings = newAirconOrderParameters.AirconSettings
 	result.AirconChanged = true
@@ -69,8 +114,7 @@ func (s TempControlService) Run(request TempControlRequest) (TempControlResult, 
 		newAirconOrderParameters.AirconSettings.AirVolume,
 		newAirconOrderParameters.AirconSettings.AirDirection,
 	)
-	slackObject := request.SlackObject
-	slackObject.SendSlack(slackMessage)
+	s.SlackNotifier.SendSlack(slackMessage)
 
 	return result, nil
 }

--- a/service/temp_control_service_test.go
+++ b/service/temp_control_service_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mski-iksm/home_controller/appliance"
+	"github.com/mski-iksm/home_controller/device"
+	"github.com/mski-iksm/home_controller/signal"
+	"github.com/mski-iksm/home_controller/temp_controller"
+)
+
+type fakeNatureClient struct {
+	devices        []device.Device
+	appliances     []appliance.Appliance
+	postCount      int
+	lastApplianceID string
+	lastSettings    signal.AirconSettings
+}
+
+func (f *fakeNatureClient) GetDevices() []device.Device {
+	return f.devices
+}
+
+func (f *fakeNatureClient) GetAppliances() []appliance.Appliance {
+	return f.appliances
+}
+
+func (f *fakeNatureClient) PostAirconSignal(applianceID string, settings signal.AirconSettings) int {
+	f.postCount++
+	f.lastApplianceID = applianceID
+	f.lastSettings = settings
+	return 200
+}
+
+type fakeSlackNotifier struct {
+	messages []string
+}
+
+func (f *fakeSlackNotifier) SendSlack(message string) {
+	f.messages = append(f.messages, message)
+}
+
+type fakeAlertNotifier struct {
+	alerts []temp_controller.TemperatureAlert
+}
+
+func (f *fakeAlertNotifier) SendTemperatureAlert(alert temp_controller.TemperatureAlert) {
+	f.alerts = append(f.alerts, alert)
+}
+
+func TestTempControlService_Run_UsesInjectedInterfaces(t *testing.T) {
+	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	currentTime := time.Date(2020, 1, 1, 5, 0, 0, 0, tokyo)
+
+	fakeClient := &fakeNatureClient{
+		devices: []device.Device{
+			{
+				Name: "Remo",
+				NewestEvents: device.NewestEvents{
+					Te: device.Temperature{
+						Val:       30.0,
+						CreatedAt: currentTime,
+					},
+				},
+			},
+		},
+		appliances: []appliance.Appliance{
+			{
+				ID: "aircon-1",
+				Device: struct {
+					Name              string    `json:"name"`
+					ID                string    `json:"id"`
+					CreatedAt         time.Time `json:"created_at"`
+					UpdatedAt         time.Time `json:"updated_at"`
+					MacAddress        string    `json:"mac_address"`
+					BtMacAddress      string    `json:"bt_mac_address"`
+					SerialNumber      string    `json:"serial_number"`
+					FirmwareVersion   string    `json:"firmware_version"`
+					TemperatureOffset int       `json:"temperature_offset"`
+					HumidityOffset    int       `json:"humidity_offset"`
+				}{
+					Name: "Remo",
+				},
+				Aircon: 1,
+				Settings: appliance.Settings{
+					Temp:      "27.0",
+					Mode:      "cool",
+					Vol:       "auto",
+					Dir:       "auto",
+					UpdatedAt: currentTime.Add(-2 * time.Hour),
+				},
+			},
+		},
+	}
+	fakeSlack := &fakeSlackNotifier{}
+	fakeAlert := &fakeAlertNotifier{}
+
+	service := TempControlService{
+		NatureClient:             fakeClient,
+		SlackNotifier:            fakeSlack,
+		TemperatureAlertNotifier: fakeAlert,
+	}
+
+	result, err := service.Run(TempControlRequest{
+		DeviceName: "Remo",
+		Settings: temp_controller.TempretureMaxMinSettings{
+			TooHotThreshold:           27.5,
+			TooColdThreshold:          24.0,
+			PreparationThreshold:      0.0,
+			MinimumTemperatureSetting: 23.0,
+			MaximumTemperatureSetting: 30.0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if fakeClient.postCount != 1 {
+		t.Fatalf("expected one aircon post, got %d", fakeClient.postCount)
+	}
+	if fakeClient.lastApplianceID != "aircon-1" {
+		t.Fatalf("expected aircon-1, got %s", fakeClient.lastApplianceID)
+	}
+	if len(fakeSlack.messages) != 1 {
+		t.Fatalf("expected one slack message, got %d", len(fakeSlack.messages))
+	}
+	if len(fakeAlert.alerts) != 1 {
+		t.Fatalf("expected one alert, got %d", len(fakeAlert.alerts))
+	}
+	if !result.AirconChanged {
+		t.Fatalf("expected aircon change result")
+	}
+}


### PR DESCRIPTION
## 概要
- `TempControlService` を `NatureClient` / `SlackNotifier` / `TemperatureAlertNotifier` の interface 注入型に変更しました
- Nature Remo / Slack / ntfy の外部依存を service の外へ分離しました
- fake 実装で注入先を差し替えるテストを追加しました

## テスト
- go test ./...