### PR TITLE
runner から温度制御 orchestration を削除

### DIFF
--- a/runner/temp_control.go
+++ b/runner/temp_control.go
@@ -1,14 +1,11 @@
 package runner
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"time"
 
-	"github.com/mski-iksm/home_controller/appliance"
-	"github.com/mski-iksm/home_controller/device"
-	"github.com/mski-iksm/home_controller/signal"
+	"github.com/mski-iksm/home_controller/service"
 	"github.com/mski-iksm/home_controller/slack"
 	"github.com/mski-iksm/home_controller/temp_controller"
 )
@@ -36,37 +33,13 @@ func TempControl(nature_api_secret string, device_name string, temptureMaxMinSet
 	currentTime := getTime()
 	appLog.Printf("時刻: %v\n", currentTime)
 
-	// get devices
-	var devices []device.Device = device.Get_devices(nature_api_secret)
-	// get appliances
-	var appliances []appliance.Appliance = appliance.Build_appliances(nature_api_secret)
-
-	// select device
-	selected_device, no_device_err := device.SelectDevice(devices, device_name)
-	if no_device_err != nil {
-		errLog.Println(no_device_err)
+	tempControlService := service.NewTempControlService(nature_api_secret, slackObject, ntfyUrl)
+	_, err := tempControlService.Run(service.TempControlRequest{
+		DeviceName: device_name,
+		Settings:   temptureMaxMinSettings,
+	})
+	if err != nil {
+		errLog.Println(err)
 		return
 	}
-
-	// filter appliances
-	filtered_appliances := appliance.FilterAppliances(appliances, device_name)
-
-	// 室温監視
-	temp_controller.MonitorTempreture(selected_device, temptureMaxMinSettings, ntfyUrl)
-
-	newAirconOrderParameters, no_change_err := temp_controller.BuildNewAirconOrderParameters(filtered_appliances, selected_device, temptureMaxMinSettings)
-
-	if no_change_err != nil {
-		errLog.Println(no_change_err)
-		return
-	}
-
-	signal.PostAirconSignal(nature_api_secret, newAirconOrderParameters.ApplianceId, newAirconOrderParameters.AirconSettings)
-
-	// deviceから今の気温を取得
-	current_tempreture := temp_controller.Get_current_temperature(selected_device)
-
-	// slackを送る
-	slackMessage := fmt.Sprintf("エアコンの設定を変更しました。\n現在温度: %v\n設定温度: %v\nモード: %v\n風量: %v\n風向: %v\n", current_tempreture.Tempreture, newAirconOrderParameters.AirconSettings.Temperature, newAirconOrderParameters.AirconSettings.OperationMode, newAirconOrderParameters.AirconSettings.AirVolume, newAirconOrderParameters.AirconSettings.AirDirection)
-	slackObject.SendSlack(slackMessage)
 }


### PR DESCRIPTION
## 概要
- `runner.TempControl` を薄い呼び出し口に整理しました
- device / appliance / signal の orchestration は `TempControlService` に委譲しました
- runner は時刻ログとエラー処理だけを担うようにしました

## テスト
- go test ./...