### PR TITLE
notify_temp 用の設定を分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ go run main.go \
   -device_name="Remo" \
   -tooHotThreshold=27.5 \
   -tooColdThreshold=24.5 \
-  -preparationThreshold=0.5 \
-  -minimumTemperatureSetting=22.0 \
-  -maximumTemperatureSetting=30.0 \
   -slackToken="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
   -slackChannel="#xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```

--- a/main.go
+++ b/main.go
@@ -121,8 +121,8 @@ func main() {
 		return
 	}
 	if action_mode == "notify_temp" {
-		temptureMaxMinSettings := temp_controller.ConstructTempretureMaxMinSettings(tooHotThreshold, tooColdThreshold, preparationThreshold, minimumTemperatureSetting, maximumTemperatureSetting)
-		runner.NotifyTemp(nature_api_secret, device_name, *temptureMaxMinSettings, slackObject)
+		temperatureNotifySettings := temp_controller.ConstructTemperatureNotifySettings(tooHotThreshold, tooColdThreshold)
+		runner.NotifyTemp(nature_api_secret, device_name, *temperatureNotifySettings, slackObject)
 		return
 	}
 }

--- a/runner/notify_temp.go
+++ b/runner/notify_temp.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mski-iksm/home_controller/temp_controller"
 )
 
-func NotifyTemp(nature_api_secret string, device_name string, temptureMaxMinSettings temp_controller.TempretureMaxMinSettings, slackObject slack.SlackObject) {
+func NotifyTemp(nature_api_secret string, device_name string, temperatureNotifySettings temp_controller.TemperatureNotifySettings, slackObject slack.SlackObject) {
 
 	// get devices
 	var devices []device.Device = device.Get_devices(nature_api_secret)
@@ -46,11 +46,11 @@ func NotifyTemp(nature_api_secret string, device_name string, temptureMaxMinSett
 	current_tempreture := temp_controller.Get_current_temperature(selected_device)
 
 	// slackを送る
-	if current_tempreture.Tempreture >= temptureMaxMinSettings.TooHotThreshold {
+	if current_tempreture.Tempreture >= temperatureNotifySettings.TooHotThreshold {
 		slackMessage := fmt.Sprintf("気温が暑いです。現在の気温: %v\n", current_tempreture.Tempreture)
 		slackObject.SendSlack(slackMessage)
 	}
-	if current_tempreture.Tempreture < temptureMaxMinSettings.TooColdThreshold {
+	if current_tempreture.Tempreture < temperatureNotifySettings.TooColdThreshold {
 		slackMessage := fmt.Sprintf("気温が寒いです。現在の気温: %v\n", current_tempreture.Tempreture)
 		slackObject.SendSlack(slackMessage)
 	}

--- a/temp_controller/types.go
+++ b/temp_controller/types.go
@@ -58,6 +58,11 @@ type TempretureMaxMinSettings struct {
 	MaximumTemperatureSetting float64
 }
 
+type TemperatureNotifySettings struct {
+	TooHotThreshold  float64
+	TooColdThreshold float64
+}
+
 var TOO_HOT_THRESHOLD_HARD_LIMIT float64 = 30.0
 var TOO_COLD_THRESHOLD_HARD_LIMIT float64 = 12.0
 var PREPARATION_THRESHOLD_HARD_LIMIT float64 = 0.0
@@ -97,4 +102,11 @@ func ConstructTempretureMaxMinSettings(tooHotThreshold float64, tooColdThreshold
 		os.Exit(1)
 	}
 	return &tempretureMaxMinSettings
+}
+
+func ConstructTemperatureNotifySettings(tooHotThreshold float64, tooColdThreshold float64) *TemperatureNotifySettings {
+	return &TemperatureNotifySettings{
+		TooHotThreshold:  tooHotThreshold,
+		TooColdThreshold: tooColdThreshold,
+	}
 }

--- a/temp_controller/types_test.go
+++ b/temp_controller/types_test.go
@@ -93,3 +93,14 @@ func TestAssertTresholdSettings(t *testing.T) {
 		})
 	}
 }
+
+func TestConstructTemperatureNotifySettings(t *testing.T) {
+	got := ConstructTemperatureNotifySettings(27.5, 24.0)
+
+	if got.TooHotThreshold != 27.5 {
+		t.Fatalf("TooHotThreshold mismatch. want %v, got %v", 27.5, got.TooHotThreshold)
+	}
+	if got.TooColdThreshold != 24.0 {
+		t.Fatalf("TooColdThreshold mismatch. want %v, got %v", 24.0, got.TooColdThreshold)
+	}
+}


### PR DESCRIPTION
## 概要
- `notify_temp` 用の設定を `TemperatureNotifySettings` として分離しました
- `notify_temp` は `TooHotThreshold` / `TooColdThreshold` のみを受け取るように変更しました
- `main.go` と README を通知専用の引数に合わせました
- `TemperatureNotifySettings` のコンストラクタを追加しました

## テスト
- go test ./...