### PR TITLE
notify_temp の判定ロジックを分離

### DIFF
--- a/runner/notify_temp.go
+++ b/runner/notify_temp.go
@@ -39,19 +39,11 @@ func NotifyTemp(nature_api_secret string, device_name string, temperatureNotifyS
 	current_aircon_setting := temp_controller.GetCurrentAirconSettings(aircon_appliance)
 
 	// エアコンの電源が入っていない場合は何もしない
-	if !current_aircon_setting.PowerOn {
+	current_tempreture := temp_controller.Get_current_temperature(selected_device)
+	temperatureNotification := temp_controller.DecideTemperatureNotification(current_tempreture, current_aircon_setting.PowerOn, temperatureNotifySettings)
+	if !temperatureNotification.ShouldNotify {
 		return
 	}
 
-	current_tempreture := temp_controller.Get_current_temperature(selected_device)
-
-	// slackを送る
-	if current_tempreture.Tempreture >= temperatureNotifySettings.TooHotThreshold {
-		slackMessage := fmt.Sprintf("気温が暑いです。現在の気温: %v\n", current_tempreture.Tempreture)
-		slackObject.SendSlack(slackMessage)
-	}
-	if current_tempreture.Tempreture < temperatureNotifySettings.TooColdThreshold {
-		slackMessage := fmt.Sprintf("気温が寒いです。現在の気温: %v\n", current_tempreture.Tempreture)
-		slackObject.SendSlack(slackMessage)
-	}
+	slackObject.SendSlack(temperatureNotification.Message)
 }

--- a/temp_controller/temp_monitor.go
+++ b/temp_controller/temp_monitor.go
@@ -43,6 +43,36 @@ func SendTemperatureAlert(ntfyUrl string, alert TemperatureAlert) {
 	http.DefaultClient.Do(req)
 }
 
+func DecideTemperatureNotification(current_tempreture CurrentTempreture, powerOn bool, temperatureNotifySettings TemperatureNotifySettings) TemperatureNotification {
+	if !powerOn {
+		return TemperatureNotification{
+			ShouldNotify: false,
+			Reason:       "power is off",
+		}
+	}
+
+	if current_tempreture.Tempreture >= temperatureNotifySettings.TooHotThreshold {
+		return TemperatureNotification{
+			ShouldNotify: true,
+			Message:      "気温が暑いです。現在の気温: " + fmt.Sprintf("%.1f", current_tempreture.Tempreture),
+			Reason:       "temperature is too hot",
+		}
+	}
+
+	if current_tempreture.Tempreture < temperatureNotifySettings.TooColdThreshold {
+		return TemperatureNotification{
+			ShouldNotify: true,
+			Message:      "気温が寒いです。現在の気温: " + fmt.Sprintf("%.1f", current_tempreture.Tempreture),
+			Reason:       "temperature is too cold",
+		}
+	}
+
+	return TemperatureNotification{
+		ShouldNotify: false,
+		Reason:       "temperature is within alert thresholds",
+	}
+}
+
 func MonitorTempreture(device device.Device, temptureMaxMinSettings TempretureMaxMinSettings, ntfyUrl string) {
 	// deviceから今の気温を取得
 	current_tempreture := Get_current_temperature(device)

--- a/temp_controller/temp_notification_test.go
+++ b/temp_controller/temp_notification_test.go
@@ -1,0 +1,88 @@
+package temp_controller
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDecideTemperatureNotification(t *testing.T) {
+	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	current := CurrentTempreture{
+		Tempreture: 28.0,
+		UpdatedAt:  time.Date(2020, 1, 1, 5, 0, 0, 0, tokyo),
+	}
+	settings := TemperatureNotifySettings{
+		TooHotThreshold:  27.5,
+		TooColdThreshold: 24.0,
+	}
+
+	tests := []struct {
+		name     string
+		powerOn  bool
+		temp     float64
+		want     TemperatureNotification
+		settings TemperatureNotifySettings
+	}{
+		{
+			name:    "tooHot",
+			powerOn: true,
+			temp:    28.0,
+			want: TemperatureNotification{
+				ShouldNotify: true,
+				Message:      "気温が暑いです。現在の気温: 28.0",
+				Reason:       "temperature is too hot",
+			},
+			settings: settings,
+		},
+		{
+			name:    "tooCold",
+			powerOn: true,
+			temp:    23.5,
+			want: TemperatureNotification{
+				ShouldNotify: true,
+				Message:      "気温が寒いです。現在の気温: 23.5",
+				Reason:       "temperature is too cold",
+			},
+			settings: settings,
+		},
+		{
+			name:    "powerOff",
+			powerOn: false,
+			temp:    28.0,
+			want: TemperatureNotification{
+				ShouldNotify: false,
+				Reason:       "power is off",
+			},
+			settings: settings,
+		},
+		{
+			name:    "withinThresholds",
+			powerOn: true,
+			temp:    25.0,
+			want: TemperatureNotification{
+				ShouldNotify: false,
+				Reason:       "temperature is within alert thresholds",
+			},
+			settings: settings,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecideTemperatureNotification(CurrentTempreture{
+				Tempreture: tt.temp,
+				UpdatedAt:  current.UpdatedAt,
+			}, tt.powerOn, tt.settings)
+
+			if got.ShouldNotify != tt.want.ShouldNotify {
+				t.Fatalf("ShouldNotify mismatch. want %v, got %v", tt.want.ShouldNotify, got.ShouldNotify)
+			}
+			if got.Reason != tt.want.Reason {
+				t.Fatalf("Reason mismatch. want %v, got %v", tt.want.Reason, got.Reason)
+			}
+			if got.Message != tt.want.Message {
+				t.Fatalf("Message mismatch. want %q, got %q", tt.want.Message, got.Message)
+			}
+		})
+	}
+}

--- a/temp_controller/types.go
+++ b/temp_controller/types.go
@@ -40,6 +40,12 @@ type TemperatureAlert struct {
 	Reason       string
 }
 
+type TemperatureNotification struct {
+	ShouldNotify bool
+	Message      string
+	Reason       string
+}
+
 type CurrentTempreture struct {
 	Tempreture float64
 	UpdatedAt  time.Time


### PR DESCRIPTION
## 概要
- `notify_temp` の Slack 通知判定を純粋関数 `DecideTemperatureNotification` に分離しました
- `runner.NotifyTemp` は判定結果を見て Slack を送るだけにしました
- power on / hot / cold / within threshold の判定テストを追加しました

## テスト
- go test ./...