### PR TITLE
notify_temp を service に移動

### DIFF
--- a/runner/notify_temp.go
+++ b/runner/notify_temp.go
@@ -1,49 +1,18 @@
 package runner
 
 import (
-	"fmt"
-
-	"github.com/mski-iksm/home_controller/appliance"
-	"github.com/mski-iksm/home_controller/device"
+	"github.com/mski-iksm/home_controller/service"
 	"github.com/mski-iksm/home_controller/slack"
 	"github.com/mski-iksm/home_controller/temp_controller"
 )
 
 func NotifyTemp(nature_api_secret string, device_name string, temperatureNotifySettings temp_controller.TemperatureNotifySettings, slackObject slack.SlackObject) {
-
-	// get devices
-	var devices []device.Device = device.Get_devices(nature_api_secret)
-	// get appliances
-	var appliances []appliance.Appliance = appliance.Build_appliances(nature_api_secret)
-
-	// select device
-	selected_device, no_device_err := device.SelectDevice(devices, device_name)
-	if no_device_err != nil {
-		errLog.Println(no_device_err)
-		return
+	notifyTempService := service.NewNotifyTempService(nature_api_secret, slackObject)
+	_, err := notifyTempService.Run(service.NotifyTempRequest{
+		DeviceName: device_name,
+		Settings:   temperatureNotifySettings,
+	})
+	if err != nil {
+		errLog.Println(err)
 	}
-
-	// filter appliances
-	filtered_appliances := appliance.FilterAppliances(appliances, device_name)
-
-	// エアコンを探して appliance を返す
-	aircon_appliance, ac_not_found_err := temp_controller.Find_aircon_appliance(filtered_appliances)
-	if ac_not_found_err != nil {
-		slackMessage := fmt.Sprintf("エアコンが見つかりませんでした")
-		slackObject.SendSlack(slackMessage)
-		errLog.Printf("エアコンが見つかりませんでした")
-		return
-	}
-
-	// 今のエアコンの設定を取得
-	current_aircon_setting := temp_controller.GetCurrentAirconSettings(aircon_appliance)
-
-	// エアコンの電源が入っていない場合は何もしない
-	current_tempreture := temp_controller.Get_current_temperature(selected_device)
-	temperatureNotification := temp_controller.DecideTemperatureNotification(current_tempreture, current_aircon_setting.PowerOn, temperatureNotifySettings)
-	if !temperatureNotification.ShouldNotify {
-		return
-	}
-
-	slackObject.SendSlack(temperatureNotification.Message)
 }

--- a/service/notify_temp_service.go
+++ b/service/notify_temp_service.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"github.com/mski-iksm/home_controller/appliance"
+	"github.com/mski-iksm/home_controller/device"
+	"github.com/mski-iksm/home_controller/slack"
+	"github.com/mski-iksm/home_controller/temp_controller"
+)
+
+type NotifyTempRequest struct {
+	DeviceName string
+	Settings   temp_controller.TemperatureNotifySettings
+}
+
+type NotifyTempResult struct {
+	CurrentTemperature      temp_controller.CurrentTempreture
+	TemperatureNotification temp_controller.TemperatureNotification
+}
+
+type NotifyTempService struct {
+	NatureClient  NatureClient
+	SlackNotifier SlackNotifier
+}
+
+func NewNotifyTempService(natureAPISecret string, slackObject slack.SlackObject) NotifyTempService {
+	return NotifyTempService{
+		NatureClient: NatureRemoClient{
+			APISecret: natureAPISecret,
+		},
+		SlackNotifier: &slackObject,
+	}
+}
+
+func (s NotifyTempService) Run(request NotifyTempRequest) (NotifyTempResult, error) {
+	var result NotifyTempResult
+
+	devices := s.NatureClient.GetDevices()
+	appliances := s.NatureClient.GetAppliances()
+
+	selectedDevice, err := device.SelectDevice(devices, request.DeviceName)
+	if err != nil {
+		return result, err
+	}
+
+	filteredAppliances := appliance.FilterAppliances(appliances, request.DeviceName)
+
+	airconAppliance, err := temp_controller.Find_aircon_appliance(filteredAppliances)
+	if err != nil {
+		s.SlackNotifier.SendSlack("エアコンが見つかりませんでした")
+		return result, err
+	}
+
+	currentAirconSetting := temp_controller.GetCurrentAirconSettings(airconAppliance)
+	currentTemperature := temp_controller.Get_current_temperature(selectedDevice)
+	result.CurrentTemperature = currentTemperature
+
+	temperatureNotification := temp_controller.DecideTemperatureNotification(
+		currentTemperature,
+		currentAirconSetting.PowerOn,
+		request.Settings,
+	)
+	result.TemperatureNotification = temperatureNotification
+
+	if !temperatureNotification.ShouldNotify {
+		return result, nil
+	}
+
+	s.SlackNotifier.SendSlack(temperatureNotification.Message)
+	return result, nil
+}

--- a/service/notify_temp_service_test.go
+++ b/service/notify_temp_service_test.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mski-iksm/home_controller/appliance"
+	"github.com/mski-iksm/home_controller/device"
+	"github.com/mski-iksm/home_controller/temp_controller"
+)
+
+func TestNotifyTempService_Run_SendsSlackForHotTemperature(t *testing.T) {
+	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	currentTime := time.Date(2020, 1, 1, 5, 0, 0, 0, tokyo)
+
+	fakeClient := &fakeNatureClient{
+		devices: []device.Device{
+			{
+				Name: "Remo",
+				NewestEvents: device.NewestEvents{
+					Te: device.Temperature{
+						Val:       28.0,
+						CreatedAt: currentTime,
+					},
+				},
+			},
+		},
+		appliances: []appliance.Appliance{
+			{
+				ID: "aircon-1",
+				Device: struct {
+					Name              string    `json:"name"`
+					ID                string    `json:"id"`
+					CreatedAt         time.Time `json:"created_at"`
+					UpdatedAt         time.Time `json:"updated_at"`
+					MacAddress        string    `json:"mac_address"`
+					BtMacAddress      string    `json:"bt_mac_address"`
+					SerialNumber      string    `json:"serial_number"`
+					FirmwareVersion   string    `json:"firmware_version"`
+					TemperatureOffset int       `json:"temperature_offset"`
+					HumidityOffset    int       `json:"humidity_offset"`
+				}{
+					Name: "Remo",
+				},
+				Aircon: 1,
+				Settings: appliance.Settings{
+					Temp:      "27.0",
+					Mode:      "cool",
+					Vol:       "auto",
+					Dir:       "auto",
+					Button:    "power-on",
+					UpdatedAt: currentTime.Add(-2 * time.Hour),
+				},
+			},
+		},
+	}
+	fakeSlack := &fakeSlackNotifier{}
+
+	service := NotifyTempService{
+		NatureClient:  fakeClient,
+		SlackNotifier: fakeSlack,
+	}
+
+	result, err := service.Run(NotifyTempRequest{
+		DeviceName: "Remo",
+		Settings: temp_controller.TemperatureNotifySettings{
+			TooHotThreshold:  27.5,
+			TooColdThreshold: 24.0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(fakeSlack.messages) != 1 {
+		t.Fatalf("expected one slack message, got %d", len(fakeSlack.messages))
+	}
+	if !result.TemperatureNotification.ShouldNotify {
+		t.Fatalf("expected notification result")
+	}
+	if result.TemperatureNotification.Reason != "temperature is too hot" {
+		t.Fatalf("unexpected reason: %s", result.TemperatureNotification.Reason)
+	}
+}
+
+func TestNotifyTempService_Run_SkipsSlackWhenWithinThreshold(t *testing.T) {
+	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	currentTime := time.Date(2020, 1, 1, 5, 0, 0, 0, tokyo)
+
+	fakeClient := &fakeNatureClient{
+		devices: []device.Device{
+			{
+				Name: "Remo",
+				NewestEvents: device.NewestEvents{
+					Te: device.Temperature{
+						Val:       25.0,
+						CreatedAt: currentTime,
+					},
+				},
+			},
+		},
+		appliances: []appliance.Appliance{
+			{
+				ID: "aircon-1",
+				Device: struct {
+					Name              string    `json:"name"`
+					ID                string    `json:"id"`
+					CreatedAt         time.Time `json:"created_at"`
+					UpdatedAt         time.Time `json:"updated_at"`
+					MacAddress        string    `json:"mac_address"`
+					BtMacAddress      string    `json:"bt_mac_address"`
+					SerialNumber      string    `json:"serial_number"`
+					FirmwareVersion   string    `json:"firmware_version"`
+					TemperatureOffset int       `json:"temperature_offset"`
+					HumidityOffset    int       `json:"humidity_offset"`
+				}{
+					Name: "Remo",
+				},
+				Aircon: 1,
+				Settings: appliance.Settings{
+					Temp:      "27.0",
+					Mode:      "cool",
+					Vol:       "auto",
+					Dir:       "auto",
+					Button:    "power-on",
+					UpdatedAt: currentTime.Add(-2 * time.Hour),
+				},
+			},
+		},
+	}
+	fakeSlack := &fakeSlackNotifier{}
+
+	service := NotifyTempService{
+		NatureClient:  fakeClient,
+		SlackNotifier: fakeSlack,
+	}
+
+	result, err := service.Run(NotifyTempRequest{
+		DeviceName: "Remo",
+		Settings: temp_controller.TemperatureNotifySettings{
+			TooHotThreshold:  27.5,
+			TooColdThreshold: 24.0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(fakeSlack.messages) != 0 {
+		t.Fatalf("expected no slack messages, got %d", len(fakeSlack.messages))
+	}
+	if result.TemperatureNotification.ShouldNotify {
+		t.Fatalf("expected no notification result")
+	}
+}


### PR DESCRIPTION
## 概要
- `notify_temp` の実行本体を `NotifyTempService` に移動しました
- runner は service を呼ぶだけにしました
- `device` / `appliance` の取得、エアコンの有無確認、Slack 通知を service 層に集約しました
- service の単体テストを追加しました

## テスト
- go test ./...