### PR TITLE
serviceのAircon context取得を共通化

### DIFF
--- a/service/aircon_context.go
+++ b/service/aircon_context.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"github.com/mski-iksm/home_controller/appliance"
+	"github.com/mski-iksm/home_controller/device"
+	"github.com/mski-iksm/home_controller/temp_controller"
+)
+
+type AirconContext struct {
+	ApplianceContext
+	AirconAppliance       appliance.Appliance
+	CurrentAirconSettings temp_controller.CurrentAirConSettings
+}
+
+type ApplianceContext struct {
+	Device             device.Device
+	FilteredAppliances []appliance.Appliance
+	CurrentTemperature temp_controller.CurrentTempreture
+}
+
+func LoadApplianceContext(client NatureClient, deviceName string) (ApplianceContext, error) {
+	var context ApplianceContext
+
+	devices := client.GetDevices()
+	appliances := client.GetAppliances()
+
+	selectedDevice, err := device.SelectDevice(devices, deviceName)
+	if err != nil {
+		return context, err
+	}
+
+	filteredAppliances := appliance.FilterAppliances(appliances, deviceName)
+
+	context.Device = selectedDevice
+	context.FilteredAppliances = filteredAppliances
+	context.CurrentTemperature = temp_controller.Get_current_temperature(selectedDevice)
+
+	return context, nil
+}
+
+func LoadAirconContext(client NatureClient, deviceName string) (AirconContext, error) {
+	applianceContext, err := LoadApplianceContext(client, deviceName)
+	if err != nil {
+		return AirconContext{}, err
+	}
+
+	airconAppliance, err := temp_controller.Find_aircon_appliance(applianceContext.FilteredAppliances)
+	if err != nil {
+		return AirconContext{}, err
+	}
+
+	context := AirconContext{
+		ApplianceContext:      applianceContext,
+		AirconAppliance:       airconAppliance,
+		CurrentAirconSettings: temp_controller.GetCurrentAirconSettings(airconAppliance),
+	}
+
+	return context, nil
+}

--- a/service/notify_temp_service.go
+++ b/service/notify_temp_service.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"github.com/mski-iksm/home_controller/appliance"
-	"github.com/mski-iksm/home_controller/device"
 	"github.com/mski-iksm/home_controller/temp_controller"
 )
 
@@ -33,31 +31,19 @@ func NewNotifyTempService(natureAPISecret string, ntfyURL string) NotifyTempServ
 func (s NotifyTempService) Run(request NotifyTempRequest) (NotifyTempResult, error) {
 	var result NotifyTempResult
 
-	devices := s.NatureClient.GetDevices()
-	appliances := s.NatureClient.GetAppliances()
-
-	selectedDevice, err := device.SelectDevice(devices, request.DeviceName)
+	airconContext, err := LoadAirconContext(s.NatureClient, request.DeviceName)
 	if err != nil {
 		return result, err
 	}
 
-	filteredAppliances := appliance.FilterAppliances(appliances, request.DeviceName)
+	result.CurrentTemperature = airconContext.CurrentTemperature
 
-	airconAppliance, err := temp_controller.Find_aircon_appliance(filteredAppliances)
-	if err != nil {
-		return result, err
-	}
-
-	currentAirconSetting := temp_controller.GetCurrentAirconSettings(airconAppliance)
-	currentTemperature := temp_controller.Get_current_temperature(selectedDevice)
-	result.CurrentTemperature = currentTemperature
-
-	if !currentAirconSetting.PowerOn {
+	if !airconContext.CurrentAirconSettings.PowerOn {
 		return result, nil
 	}
 
 	temperatureAlert := temp_controller.DecideTemperatureAlert(
-		currentTemperature,
+		airconContext.CurrentTemperature,
 		temp_controller.TempretureMaxMinSettings{
 			TooHotThreshold:  request.Settings.TooHotThreshold,
 			TooColdThreshold: request.Settings.TooColdThreshold,

--- a/service/temp_control_service.go
+++ b/service/temp_control_service.go
@@ -79,24 +79,18 @@ func NewTempControlService(natureAPISecret string, slackObject slack.SlackObject
 func (s TempControlService) Run(request TempControlRequest) (TempControlResult, error) {
 	var result TempControlResult
 
-	devices := s.NatureClient.GetDevices()
-	appliances := s.NatureClient.GetAppliances()
-
-	selectedDevice, err := device.SelectDevice(devices, request.DeviceName)
+	applianceContext, err := LoadApplianceContext(s.NatureClient, request.DeviceName)
 	if err != nil {
 		return result, err
 	}
 
-	filteredAppliances := appliance.FilterAppliances(appliances, request.DeviceName)
+	result.CurrentTemperature = applianceContext.CurrentTemperature
 
-	currentTemperature := temp_controller.Get_current_temperature(selectedDevice)
-	result.CurrentTemperature = currentTemperature
-
-	temperatureAlert := temp_controller.DecideTemperatureAlert(currentTemperature, request.Settings)
+	temperatureAlert := temp_controller.DecideTemperatureAlert(applianceContext.CurrentTemperature, request.Settings)
 	result.TemperatureAlert = temperatureAlert
 	s.TemperatureAlertNotifier.SendTemperatureAlert(temperatureAlert)
 
-	newAirconOrderParameters, err := temp_controller.BuildNewAirconOrderParameters(filteredAppliances, selectedDevice, request.Settings)
+	newAirconOrderParameters, err := temp_controller.BuildNewAirconOrderParameters(applianceContext.FilteredAppliances, applianceContext.Device, request.Settings)
 	if err != nil {
 		return result, err
 	}
@@ -108,7 +102,7 @@ func (s TempControlService) Run(request TempControlRequest) (TempControlResult, 
 
 	slackMessage := fmt.Sprintf(
 		"エアコンの設定を変更しました。\n現在温度: %v\n設定温度: %v\nモード: %v\n風量: %v\n風向: %v\n",
-		currentTemperature.Tempreture,
+		applianceContext.CurrentTemperature.Tempreture,
 		newAirconOrderParameters.AirconSettings.Temperature,
 		newAirconOrderParameters.AirconSettings.OperationMode,
 		newAirconOrderParameters.AirconSettings.AirVolume,


### PR DESCRIPTION
## 概要
- service 層に ApplianceContext / AirconContext の取得 helper を追加
- temp_control と notify_temp で重複していた Nature Remo 取得、device 選択、appliance filter、現在温度取得を共通化
- notify_temp は AirconContext 経由で aircon 探索と現在設定取得も共通 helper に寄せました
- temp_control は既存の制御処理順を保つため、制御判断本体は BuildNewAirconOrderParameters 呼び出しを維持しています

## テスト
- go test ./...